### PR TITLE
Patched functionality for ST2. Fixes #2

### DIFF
--- a/maybs-quit.py
+++ b/maybs-quit.py
@@ -10,7 +10,7 @@ class QuitGuardCommand(sublime_plugin.TextCommand):
 		('Cancel', None, ),
 	)
 
-	OPTION_NAMES = tuple((opt[0] for opt in OPTIONS))
+	OPTION_NAMES = list((opt[0] for opt in OPTIONS))
 
 	def run(self, edit):
 		self.view.window().show_quick_panel(self.OPTION_NAMES, self.on_done)


### PR DESCRIPTION
I tried moving from `tuple` to `list` for `OPTION_NAMES` and it seems to have done the trick for fixing #2, Sublime Text 2 functionality.
